### PR TITLE
typical sqs events don't return a body, just a hash of unsuccessful work

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -181,7 +181,7 @@ final class LambdaRuntime
     {
         $url = "http://{$this->apiUrl}/2018-06-01/runtime/invocation/$invocationId/response";
 
-        \strlen($responseData['body']) > 6291456 // 6MiB
+        \strlen($responseData['body'] ?? '') > 6291456 // 6MiB
             ? $this->postLargeResponse($url, $responseData)
             : $this->postJson($url, $responseData);
     }


### PR DESCRIPTION
# The Problem
All of our SQS handler lambdas fail with this fork.
```
b9deedc1-a5ef-5625-a037-b356898d9f72	Invoke Error	
{
    "errorType": "TypeError",
    "errorMessage": "strlen(): Argument #1 ($string) must be of type string, null given",
    "stack": [
        "#0 /var/www/vendor/awesome/bref/src/Runtime/LambdaRuntime.php(93): Bref\\Runtime\\LambdaRuntime->sendResponse('b9deedc1-a5ef-5...', NULL)",
        "#1 /var/www/vendor/awesome/lambda-events/src/Ric/InvokerTrait.php(29): Bref\\Runtime\\LambdaRuntime->processNextEvent(Object(Awesome\\Event\\Lambda\\Sqs\\Handler))",
        "#2 /var/www/app/lambda-sqs.php(36): Awesome\\Event\\Lambda\\Ric\\FunctionInvoker->invoke()",
        "#3 /var/www/app/lambda-sqs.php(37): {closure}()",
        "#4 {main}"
    ]
}
```
# The Solution
Because SQS Handlers return an array of failed message keys instead of a single body, handle the fact that `$responseData['body']` may not be set by defaulting it to `''` in the `strlen()` call. This will result in a length of 0, and `0 > 6291456` being false it will hit the leg to do `postJson()`, which is what would have happened without the large response support.