### PR TITLE
Cherry-pick changes from support-larger-payloads-1.7.39 into master

### DIFF
--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -24,6 +24,10 @@ abstract class HttpHandler implements Handler
 
         $response = $this->handleRequest($httpEvent, $context);
 
+        if ($httpEvent->doesBodyRequireLargeResponse()) {
+            return $response->toLargeResponse();
+        }
+
         if ($httpEvent->isFormatV2()) {
             return $response->toApiGatewayFormatV2();
         }

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -47,6 +47,14 @@ final class HttpRequestEvent implements LambdaEvent
         return $this->event;
     }
 
+    /**
+     * Responses >6MiB (up to 20MiB) must be "streamed" to the Lambda response URL.
+     */
+    public function doesBodyRequireLargeResponse(): bool
+    {
+        return \strlen($this->getBody()) > 6291456; // 6MiB
+    }
+
     public function getBody(): string
     {
         $requestBody = $this->event['body'] ?? '';

--- a/src/Event/Http/HttpResponse.php
+++ b/src/Event/Http/HttpResponse.php
@@ -90,6 +90,19 @@ final class HttpResponse
     }
 
     /**
+     * Builds a "large" (>6MiB) response to use when "streaming", since that's the only way to return "large" responses.
+     *
+     * @return array<string, mixed>
+     */
+    public function toLargeResponse(): array {
+        return [
+            'statusCode' => $this->statusCode,
+            'headers' => $this->headers,
+            'body' => $this->body,
+        ];
+    }
+
+    /**
      * See https://github.com/zendframework/zend-diactoros/blob/754a2ceb7ab753aafe6e3a70a1fb0370bde8995c/src/Response/SapiEmitterTrait.php#L96
      */
     private function capitalizeHeaderName(string $name): string

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -184,7 +184,7 @@ final class LambdaRuntime
     {
         $url = "http://$this->apiUrl/2018-06-01/runtime/invocation/$invocationId/response";
 
-        \strlen($responseData['body']) > 6291456 // 6MiB
+        \strlen($responseData['body'] ?? '') > 6291456 // 6MiB
             ? $this->postLargeResponse($url, $responseData)
             : $this->postJson($url, $responseData);
     }


### PR DESCRIPTION
These branches have diverged to where it's difficult to reconcile.  There are changes on both branches.  

Tags `1.73.9.1` and `1.73.9.2` are built off of the `support-larger-payloads-1.7.39` branch, while `1.73.9.3` was built off of a branch that does not exist in this repo, but seems to be the same as the `support-larger-payloads-1.7.39` branch.  

The commits from `1.73.9.1` and `1.73.9.2` are not on master, but the commit for `1.73.9.3` is on master.

This PR attempts to clean things up by cherry-picking the commits from `1.73.9.1` and `1.73.9.2` onto the master branch so we have a unified codebase to work from.